### PR TITLE
Don't close when clicked inside of tray

### DIFF
--- a/global-custom-nav.js
+++ b/global-custom-nav.js
@@ -399,7 +399,7 @@
     // close tray when user clicks outside the tray
     window.addEventListener('click', function (e) {
       if (document.querySelector(`#nav-tray-portal > #${item.slug}-tray`) !== null) {
-        if (document.getElementById(`main`).contains(e.target) || !document.getElementById(`${item.slug}-item`).contains(e.target)) {
+        if (!document.getElementById(`${item.slug}-tray`)?.contains(e.target) && (document.getElementById(`main`).contains(e.target) || !document.getElementById(`${item.slug}-item`).contains(e.target))) {
           document.getElementById(`${item.slug}-tray`).remove();
           document.getElementById(item.slug).closest('li').classList.remove(globalCustomNav.cfg.glbl.trayActiveClass);
         }


### PR DESCRIPTION
This adds an extra check in the glbl_tray_focus handler to make sure the target event wasn't inside of the tray.  This way the tray doesn't unexpectedly close when clicking inside the tray.  Now it requires clicking outside of the tray for it to close based on this.